### PR TITLE
fix: return undefined from FetchCacher#load on NotFound

### DIFF
--- a/cache.ts
+++ b/cache.ts
@@ -21,6 +21,13 @@ export class FetchCacher {
     checksum?: string,
   ): Promise<LoadResponse | undefined> => {
     const url = new URL(specifier);
-    return this.#fileFetcher.fetchOnce(url, { cacheSetting, checksum });
+    return this.#fileFetcher.fetchOnce(url, { cacheSetting, checksum })
+      .catch((e) => {
+        if (e instanceof Deno.errors.NotFound) {
+          return undefined;
+        }
+
+        throw new Error("FetchCacher#load failed", { cause: e });
+      });
   };
 }

--- a/cache.ts
+++ b/cache.ts
@@ -27,7 +27,7 @@ export class FetchCacher {
           return undefined;
         }
 
-        throw new Error("FetchCacher#load failed", { cause: e });
+        throw e;
       });
   };
 }

--- a/cache_test.ts
+++ b/cache_test.ts
@@ -1,0 +1,47 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import { FetchCacher } from "./cache.ts";
+import { DenoDir } from "./deno_dir.ts";
+import { FileFetcher } from "./file_fetcher.ts";
+import { createGraph } from "@deno/graph";
+import { assertEquals } from "@std/assert/assert-equals";
+
+async function setup() {
+  const tempdir = await Deno.makeTempDir({
+    prefix: "deno_cache_dir_cache_test",
+  });
+  const denoDir = new DenoDir(tempdir);
+  const fileFetcher = new FileFetcher(
+    () => {
+      return denoDir.createHttpCache();
+    },
+    "use",
+    true,
+  );
+  return new FetchCacher(fileFetcher);
+}
+
+Deno.test("FetchCacher#load works with createGraph to deal with a JSR package", async () => {
+  const fetchCacher = await setup();
+
+  const graph = await createGraph("jsr:@deno/gfm@0.9.0", {
+    load: fetchCacher.load,
+  });
+
+  assertEquals(graph.roots, ["jsr:@deno/gfm@0.9.0"]);
+  assertEquals(
+    graph.redirects["jsr:@deno/gfm@0.9.0"],
+    "https://jsr.io/@deno/gfm/0.9.0/mod.ts",
+  );
+});
+
+Deno.test("FetchCacher#load works with createGraph to deal with a deno.land/x package", async () => {
+  const fetchCacher = await setup();
+
+  const graph = await createGraph("https://deno.land/x/oak@v9.0.1/mod.ts", {
+    load: fetchCacher.load,
+  });
+
+  assertEquals(graph.roots, ["https://deno.land/x/oak@v9.0.1/mod.ts"]);
+  assertEquals(graph.redirects, {});
+});


### PR DESCRIPTION
This makes `FetchCacher#load` return undefined when the file fetcher returns NotFound error in order to align it with [Deno CLI's implementation](https://github.com/denoland/deno/blob/1a0cb5b5312941521ab021cfe9eaed498f35900b/cli/cache/mod.rs#L422):

```rust
let error_class_name = get_error_class_name(&err);
match error_class_name {
  "NotFound" => Ok(None),
  "NotCached" if options.cache_setting == LoaderCacheSetting::Only => Ok(None),
  _ => Err(err),
}
```

---

With this patch, [deno_emit](https://github.com/denoland/deno_emit) can bundle source code containing imports from JSR.

Let's say we have a bundle target script as follows:

```ts
import { add } from "jsr:@magurotuna/test-add";

console.log(add(1, 3));
```

Without this patch, running `bundle` function from deno_emit on this script gives:

```
error: Uncaught (in promise) Error: Unable to output during bundling: load_transformed failed: failed to analyze module: failed to resolve jsr:@magurotuna/test-add from file:///Users/yusuke/Repo/github.com/magurotuna/deno_emit/js/maguro_add.ts: Cannot resolve "jsr:@magurotuna/test-add" from "file:///Users/yusuke/Repo/github.com/magurotuna/deno_emit/js/maguro_add.ts".
      const ret = new Error(getStringFromWasm0(arg0, arg1));
                  ^
    at __wbg_new_28c511d9baebfa89 (file:///Users/yusuke/Repo/github.com/magurotuna/deno_emit/js/emit.generated.js:563:19)
    at <anonymous> (wasm://wasm/010ad402:1:3297307)
    at <anonymous> (wasm://wasm/010ad402:1:358125)
    at <anonymous> (wasm://wasm/010ad402:1:1823927)
    at <anonymous> (wasm://wasm/010ad402:1:2937828)
    at __wbg_adapter_46 (file:///Users/yusuke/Repo/github.com/magurotuna/deno_emit/js/emit.generated.js:247:6)
    at real (file:///Users/yusuke/Repo/github.com/magurotuna/deno_emit/js/emit.generated.js:231:14)
    at ext:core/01_core.js:291:9
    at eventLoopTick (ext:core/01_core.js:175:7)
```

With this patch, it can generate:

```js
function add(a, b) {
    return a + b;
}
console.log(add(1, 3));
```

Ref https://github.com/denoland/deno_emit/issues/167