### PR TITLE
chore: update dependencies & deno fmt

### DIFF
--- a/cache_test.ts
+++ b/cache_test.ts
@@ -4,7 +4,7 @@ import { FetchCacher } from "./cache.ts";
 import { DenoDir } from "./deno_dir.ts";
 import { FileFetcher } from "./file_fetcher.ts";
 import { createGraph } from "@deno/graph";
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 
 async function setup() {
   const tempdir = await Deno.makeTempDir({

--- a/deno.json
+++ b/deno.json
@@ -8,9 +8,7 @@
   },
   "lint": {
     "rules": {
-      "include": [
-        "no-console"
-      ]
+      "include": ["no-console"]
     }
   },
   "publish": {
@@ -22,16 +20,14 @@
       "!lib/deno_cache_dir.generated.js"
     ]
   },
-  "exclude": [
-    "target"
-  ],
+  "exclude": ["target"],
   "exports": "./mod.ts",
   "imports": {
-    "@deno/graph": "jsr:@deno/graph@^0.73.1",
-    "@std/assert": "jsr:@std/assert@^0.223",
-    "@std/fmt": "jsr:@std/fmt@^0.223",
-    "@std/fs": "jsr:@std/fs@^0.223",
-    "@std/io": "jsr:@std/io@^0.223",
-    "@std/path": "jsr:@std/path@^0.223"
+    "@deno/graph": "jsr:@deno/graph@^0.86.0",
+    "@std/assert": "jsr:@std/assert@^1.0.8",
+    "@std/fmt": "jsr:@std/fmt@^1.0.3",
+    "@std/fs": "jsr:@std/fs@^1.0.6",
+    "@std/io": "jsr:@std/io@^0.225.0",
+    "@std/path": "jsr:@std/path@^1.0.8"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,60 +1,58 @@
 {
-  "version": "3",
-  "packages": {
-    "specifiers": {
-      "jsr:@deno/graph@^0.73.1": "jsr:@deno/graph@0.73.1",
-      "jsr:@std/assert@^0.223": "jsr:@std/assert@0.223.0",
-      "jsr:@std/assert@^0.223.0": "jsr:@std/assert@0.223.0",
-      "jsr:@std/bytes@^0.223.0": "jsr:@std/bytes@0.223.0",
-      "jsr:@std/fmt@^0.223": "jsr:@std/fmt@0.223.0",
-      "jsr:@std/fmt@^0.223.0": "jsr:@std/fmt@0.223.0",
-      "jsr:@std/fs@^0.223": "jsr:@std/fs@0.223.0",
-      "jsr:@std/io@^0.223": "jsr:@std/io@0.223.0",
-      "jsr:@std/path@^0.223": "jsr:@std/path@0.223.0"
+  "version": "4",
+  "specifiers": {
+    "jsr:@deno/graph@0.86": "0.86.0",
+    "jsr:@std/assert@^1.0.8": "1.0.8",
+    "jsr:@std/bytes@^1.0.2": "1.0.4",
+    "jsr:@std/fmt@^1.0.3": "1.0.3",
+    "jsr:@std/fs@^1.0.6": "1.0.6",
+    "jsr:@std/internal@^1.0.5": "1.0.5",
+    "jsr:@std/io@0.225": "0.225.0",
+    "jsr:@std/path@^1.0.8": "1.0.8"
+  },
+  "jsr": {
+    "@deno/graph@0.86.0": {
+      "integrity": "749bece1db357b1b1e47708b8fd3badea5fdfc3f9e714167c7d985c4d7f6df26"
     },
-    "jsr": {
-      "@deno/graph@0.73.1": {
-        "integrity": "cd69639d2709d479037d5ce191a422eabe8d71bb68b0098344f6b07411c84d41"
-      },
-      "@std/assert@0.223.0": {
-        "integrity": "eb8d6d879d76e1cc431205bd346ed4d88dc051c6366365b1af47034b0670be24",
-        "dependencies": [
-          "jsr:@std/fmt@^0.223.0"
-        ]
-      },
-      "@std/bytes@0.223.0": {
-        "integrity": "84b75052cd8680942c397c2631318772b295019098f40aac5c36cead4cba51a8"
-      },
-      "@std/fmt@0.223.0": {
-        "integrity": "6deb37794127dfc7d7bded2586b9fc6f5d50e62a8134846608baf71ffc1a5208"
-      },
-      "@std/fs@0.223.0": {
-        "integrity": "3b4b0550b2c524cbaaa5a9170c90e96cbb7354e837ad1bdaf15fc9df1ae9c31c"
-      },
-      "@std/io@0.223.0": {
-        "integrity": "2d8c3c2ab3a515619b90da2c6ff5ea7b75a94383259ef4d02116b228393f84f1",
-        "dependencies": [
-          "jsr:@std/assert@^0.223.0",
-          "jsr:@std/bytes@^0.223.0"
-        ]
-      },
-      "@std/path@0.223.0": {
-        "integrity": "593963402d7e6597f5a6e620931661053572c982fc014000459edc1f93cc3989",
-        "dependencies": [
-          "jsr:@std/assert@^0.223.0"
-        ]
-      }
+    "@std/assert@1.0.8": {
+      "integrity": "ebe0bd7eb488ee39686f77003992f389a06c3da1bbd8022184804852b2fa641b",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/bytes@1.0.4": {
+      "integrity": "11a0debe522707c95c7b7ef89b478c13fb1583a7cfb9a85674cd2cc2e3a28abc"
+    },
+    "@std/fmt@1.0.3": {
+      "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
+    },
+    "@std/fs@1.0.6": {
+      "integrity": "42b56e1e41b75583a21d5a37f6a6a27de9f510bcd36c0c85791d685ca0b85fa2",
+      "dependencies": [
+        "jsr:@std/path"
+      ]
+    },
+    "@std/internal@1.0.5": {
+      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    },
+    "@std/io@0.225.0": {
+      "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
+    },
+    "@std/path@1.0.8": {
+      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
     }
   },
-  "remote": {},
   "workspace": {
     "dependencies": [
-      "jsr:@deno/graph@^0.73.1",
-      "jsr:@std/assert@^0.223",
-      "jsr:@std/fmt@^0.223",
-      "jsr:@std/fs@^0.223",
-      "jsr:@std/io@^0.223",
-      "jsr:@std/path@^0.223"
+      "jsr:@deno/graph@0.86",
+      "jsr:@std/assert@^1.0.8",
+      "jsr:@std/fmt@^1.0.3",
+      "jsr:@std/fs@^1.0.6",
+      "jsr:@std/io@0.225",
+      "jsr:@std/path@^1.0.8"
     ]
   }
 }


### PR DESCRIPTION
This pull request updates the dependencies of this package in the hopes that it will eventually make it upstream to remove these warnings when running tests locally. 
![image](https://github.com/user-attachments/assets/fb374d38-4e69-4846-83f6-5259cfd31158)
For these warnings to disappear in `@std`, `@deno/doc` would need an update as well.
