### PR TITLE
fix: pass along the global cache's checksum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,7 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/rs_lib/Cargo.toml
+++ b/rs_lib/Cargo.toml
@@ -34,7 +34,7 @@ log = "0.4.19"
 once_cell = "1.18.0"
 parking_lot = "0.12.1"
 serde = "1.0.183"
-serde_json = "1.0.104"
+serde_json = { version = "1.0.104", features = ["preserve_order"] }
 sha2 = "0.10.0"
 thiserror = "2"
 url = { version = "2.5.1", features = ["serde"] }

--- a/rs_lib/src/cache.rs
+++ b/rs_lib/src/cache.rs
@@ -142,6 +142,14 @@ pub struct SerializedCachedUrlMetadata {
 pub struct CacheEntry {
   pub metadata: SerializedCachedUrlMetadata,
   pub content: Cow<'static, [u8]>,
+  /// Checksum of the content that should be used in the lockfile.
+  ///
+  /// This is necesary to pass along when the provided content differs
+  /// from the checksum that should be stored (ex. JSR metadata files
+  /// are stored with less information in the vendor directory than
+  /// in the global directory, but we need the global directory checksum
+  /// and the local dir's checksum)
+  pub original_checksum: Option<String>,
 }
 
 /// Computed cache key, which can help reduce the work of computing the cache key multiple times.

--- a/rs_lib/src/cache.rs
+++ b/rs_lib/src/cache.rs
@@ -142,14 +142,6 @@ pub struct SerializedCachedUrlMetadata {
 pub struct CacheEntry {
   pub metadata: SerializedCachedUrlMetadata,
   pub content: Cow<'static, [u8]>,
-  /// Checksum of the content that should be used in the lockfile.
-  ///
-  /// This is necesary to pass along when the provided content differs
-  /// from the checksum that should be stored (ex. JSR metadata files
-  /// are stored with less information in the vendor directory than
-  /// in the global directory, but we need the global directory checksum
-  /// and the local dir's checksum)
-  pub original_checksum: Option<String>,
 }
 
 /// Computed cache key, which can help reduce the work of computing the cache key multiple times.

--- a/rs_lib/src/local.rs
+++ b/rs_lib/src/local.rs
@@ -353,9 +353,11 @@ fn is_jsr_version_metadata_url(url: &Url, jsr_url: &Url) -> bool {
 }
 
 fn transform_jsr_version_metadata(content: &[u8]) -> Option<Vec<u8>> {
+  let checksum = checksum(content);
   let mut json_data =
     serde_json::from_slice::<serde_json::Value>(content).ok()?;
   let obj = json_data.as_object_mut()?;
+  obj.insert("originalChecksum".into(), checksum.into());
   let keys_to_remove = obj
     .keys()
     .filter(|k| k.starts_with("moduleGraph"))
@@ -366,7 +368,6 @@ fn transform_jsr_version_metadata(content: &[u8]) -> Option<Vec<u8>> {
   }
   for key in keys_to_remove {
     obj.remove(&key);
-  }
   serde_json::to_vec(&json_data).ok()
 }
 


### PR DESCRIPTION
Part of fix for https://github.com/denoland/deno/issues/29432

I think we need to store the original checksum along with this data in the vendor folder.