### PR TITLE
fix: re-export HeaderName and HeaderValue

### DIFF
--- a/rs_lib/src/file_fetcher/mod.rs
+++ b/rs_lib/src/file_fetcher/mod.rs
@@ -46,6 +46,7 @@ pub use auth_tokens::AuthTokens;
 pub use http::HeaderMap;
 pub use http::HeaderName;
 pub use http::HeaderValue;
+pub use http::StatusCode;
 
 /// Indicates how cached source files should be handled.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/rs_lib/src/file_fetcher/mod.rs
+++ b/rs_lib/src/file_fetcher/mod.rs
@@ -17,7 +17,6 @@ use http::header::ACCEPT;
 use http::header::AUTHORIZATION;
 use http::header::IF_NONE_MATCH;
 use http::header::LOCATION;
-use http::HeaderValue;
 use log::debug;
 use sys_traits::FsFileMetadata;
 use sys_traits::FsMetadataValue;
@@ -45,6 +44,8 @@ pub use auth_tokens::AuthToken;
 pub use auth_tokens::AuthTokenData;
 pub use auth_tokens::AuthTokens;
 pub use http::HeaderMap;
+pub use http::HeaderName;
+pub use http::HeaderValue;
 
 /// Indicates how cached source files should be handled.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/rs_lib/src/global/mod.rs
+++ b/rs_lib/src/global/mod.rs
@@ -60,7 +60,7 @@ pub struct GlobalHttpCache<Sys: GlobalHttpCacheSys> {
 
 impl<Sys: GlobalHttpCacheSys> GlobalHttpCache<Sys> {
   pub fn new(sys: Sys, path: PathBuf) -> Self {
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(not(target_arch = "wasm32"))]
     assert!(path.is_absolute());
     Self { path, sys }
   }

--- a/rs_lib/src/local.rs
+++ b/rs_lib/src/local.rs
@@ -68,7 +68,7 @@ pub struct LocalLspHttpCache<TSys: LocalHttpCacheSys> {
 
 impl<TSys: LocalHttpCacheSys> LocalLspHttpCache<TSys> {
   pub fn new(path: PathBuf, global_cache: GlobalHttpCacheRc<TSys>) -> Self {
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(not(target_arch = "wasm32"))]
     assert!(path.is_absolute());
     let manifest = LocalCacheManifest::new_for_lsp(
       path.join("manifest.json"),
@@ -245,7 +245,7 @@ impl<TSys: LocalHttpCacheSys> LocalHttpCache<TSys> {
     allow_global_to_local: GlobalToLocalCopy,
     jsr_registry_url: Url,
   ) -> Self {
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(not(target_arch = "wasm32"))]
     assert!(path.is_absolute());
     let manifest = LocalCacheManifest::new(
       path.join("manifest.json"),


### PR DESCRIPTION
So someone doesn't need to deal with the http crate if using this.